### PR TITLE
Add auth flow for SaaS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ frontend/node_modules/
 .env
 .pnp.*
 .yarn/
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -37,3 +37,13 @@ npm install
 npm run dev
 ```
 
+
+To start the backend API server:
+
+```bash
+cd backend
+pip install -r requirements.txt
+uvicorn backend.main:app --reload
+```
+
+The backend exposes `/signup` and `/login` endpoints for account creation and authentication.

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,14 @@
+# Calioris Backend
+
+This directory contains the FastAPI application for authentication and organization management.
+
+## Development
+
+Install dependencies and run the app:
+
+```bash
+pip install -r requirements.txt
+uvicorn backend.main:app --reload
+```
+
+The default database is a local SQLite file `app.db`. You can override the database URL using the `DATABASE_URL` environment variable (e.g. a PostgreSQL connection string).

--- a/backend/database.py
+++ b/backend/database.py
@@ -1,0 +1,13 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+import os
+
+DATABASE_URL = os.getenv('DATABASE_URL', 'sqlite:///./app.db')
+
+enable_sqlite_fk = DATABASE_URL.startswith('sqlite')
+engine = create_engine(
+    DATABASE_URL, connect_args={'check_same_thread': False} if enable_sqlite_fk else {}
+)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+Base = declarative_base()

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,56 @@
+from fastapi import FastAPI, Depends, HTTPException
+from sqlalchemy.orm import Session
+from passlib.context import CryptContext
+
+from .database import SessionLocal, engine, Base
+from . import models, schemas
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+Base.metadata.create_all(bind=engine)
+
+app = FastAPI(title="Calioris API")
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+def get_password_hash(password: str) -> str:
+    return pwd_context.hash(password)
+
+def verify_password(plain_password: str, hashed_password: str) -> bool:
+    return pwd_context.verify(plain_password, hashed_password)
+
+@app.post("/signup", response_model=schemas.UserRead)
+def signup(user: schemas.UserCreate, db: Session = Depends(get_db)):
+    existing = db.query(models.User).filter(models.User.email == user.email).first()
+    if existing:
+        raise HTTPException(status_code=400, detail="Email already registered")
+
+    org = db.query(models.Organization).filter(models.Organization.name == user.organization).first()
+    if not org:
+        org = models.Organization(name=user.organization)
+        db.add(org)
+        db.flush()
+
+    db_user = models.User(
+        email=user.email,
+        hashed_password=get_password_hash(user.password),
+        organization=org,
+    )
+    db.add(db_user)
+    db.commit()
+    db.refresh(db_user)
+    return schemas.UserRead(id=db_user.id, email=db_user.email, organization=org.name)
+
+@app.post("/login", response_model=schemas.UserRead)
+def login(credentials: schemas.UserLogin, db: Session = Depends(get_db)):
+    db_user = db.query(models.User).filter(models.User.email == credentials.email).first()
+    if not db_user or not verify_password(credentials.password, db_user.hashed_password):
+        raise HTTPException(status_code=400, detail="Invalid credentials")
+    org = db_user.organization.name if db_user.organization else None
+    return schemas.UserRead(id=db_user.id, email=db_user.email, organization=org)

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,0 +1,20 @@
+from sqlalchemy import Column, Integer, String, ForeignKey
+from sqlalchemy.orm import relationship
+
+from .database import Base
+
+class Organization(Base):
+    __tablename__ = 'organizations'
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, unique=True, index=True, nullable=False)
+
+    users = relationship('User', back_populates='organization')
+
+class User(Base):
+    __tablename__ = 'users'
+    id = Column(Integer, primary_key=True, index=True)
+    email = Column(String, unique=True, index=True, nullable=False)
+    hashed_password = Column(String, nullable=False)
+    organization_id = Column(Integer, ForeignKey('organizations.id'))
+
+    organization = relationship('Organization', back_populates='users')

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,5 @@
+fastapi
+uvicorn
+sqlalchemy
+passlib[bcrypt]
+python-dotenv

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -1,0 +1,19 @@
+from pydantic import BaseModel
+from typing import Optional
+
+class UserCreate(BaseModel):
+    email: str
+    password: str
+    organization: str
+
+class UserLogin(BaseModel):
+    email: str
+    password: str
+
+class UserRead(BaseModel):
+    id: int
+    email: str
+    organization: str
+
+    class Config:
+        orm_mode = True

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "react-router-dom": "^6.23.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -34,3 +34,32 @@
 .asset-table tr:nth-child(odd) {
   background-color: var(--color-soft-lavender);
 }
+
+.nav {
+  background: var(--color-deep-indigo);
+  padding: 0.5rem;
+}
+
+.nav a {
+  color: var(--color-pearl-white);
+  margin-right: 1rem;
+  text-decoration: none;
+}
+
+.auth-form {
+  max-width: 300px;
+  margin: 2rem auto;
+  display: flex;
+  flex-direction: column;
+}
+
+.auth-form input,
+.auth-form button {
+  margin-bottom: 0.5rem;
+  padding: 0.5rem;
+}
+
+.error {
+  color: red;
+  margin-bottom: 0.5rem;
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,46 +1,22 @@
-import { useState } from 'react'
+import { BrowserRouter, Routes, Route, Link } from 'react-router-dom'
+import Home from './Home'
+import Login from './Login'
+import Signup from './Signup'
 import './App.css'
 
-interface Asset {
-  id: number
-  name: string
-  owner: string
-}
-
-function App() {
-  const [assets] = useState<Asset[]>([
-    { id: 1, name: 'Laptop - MacBook Pro', owner: 'Alice' },
-    { id: 2, name: 'Server - API 01', owner: 'Bob' },
-    { id: 3, name: 'Switch - Cisco 24p', owner: 'IT Dept' },
-  ])
-
+export default function App() {
   return (
-    <div className="container">
-      <header className="header">
-        <h1>Calioris Assets</h1>
-      </header>
-      <main>
-        <table className="asset-table">
-          <thead>
-            <tr>
-              <th>ID</th>
-              <th>Name</th>
-              <th>Owner</th>
-            </tr>
-          </thead>
-          <tbody>
-            {assets.map((asset) => (
-              <tr key={asset.id}>
-                <td>{asset.id}</td>
-                <td>{asset.name}</td>
-                <td>{asset.owner}</td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </main>
-    </div>
+    <BrowserRouter>
+      <nav className="nav">
+        <Link to="/">Home</Link>
+        <Link to="/login">Login</Link>
+        <Link to="/signup">Sign Up</Link>
+      </nav>
+      <Routes>
+        <Route path="/" element={<Home />} />
+        <Route path="/login" element={<Login />} />
+        <Route path="/signup" element={<Signup />} />
+      </Routes>
+    </BrowserRouter>
   )
 }
-
-export default App

--- a/frontend/src/Home.tsx
+++ b/frontend/src/Home.tsx
@@ -1,0 +1,43 @@
+import { useState } from 'react'
+
+interface Asset {
+  id: number
+  name: string
+  owner: string
+}
+
+export default function Home() {
+  const [assets] = useState<Asset[]>([
+    { id: 1, name: 'Laptop - MacBook Pro', owner: 'Alice' },
+    { id: 2, name: 'Server - API 01', owner: 'Bob' },
+    { id: 3, name: 'Switch - Cisco 24p', owner: 'IT Dept' },
+  ])
+
+  return (
+    <div className="container">
+      <header className="header">
+        <h1>Calioris Assets</h1>
+      </header>
+      <main>
+        <table className="asset-table">
+          <thead>
+            <tr>
+              <th>ID</th>
+              <th>Name</th>
+              <th>Owner</th>
+            </tr>
+          </thead>
+          <tbody>
+            {assets.map((asset) => (
+              <tr key={asset.id}>
+                <td>{asset.id}</td>
+                <td>{asset.name}</td>
+                <td>{asset.owner}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </main>
+    </div>
+  )
+}

--- a/frontend/src/Login.tsx
+++ b/frontend/src/Login.tsx
@@ -1,0 +1,45 @@
+import { useState } from 'react'
+
+export default function Login() {
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState('')
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError('')
+    const res = await fetch('/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, password }),
+    })
+    if (res.ok) {
+      alert('Logged in!')
+    } else {
+      const data = await res.json()
+      setError(data.detail ?? 'Login failed')
+    }
+  }
+
+  return (
+    <form onSubmit={submit} className="auth-form">
+      <h2>Login</h2>
+      {error && <div className="error">{error}</div>}
+      <input
+        type="email"
+        placeholder="Email"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        required
+      />
+      <input
+        type="password"
+        placeholder="Password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        required
+      />
+      <button type="submit">Login</button>
+    </form>
+  )
+}

--- a/frontend/src/Signup.tsx
+++ b/frontend/src/Signup.tsx
@@ -1,0 +1,53 @@
+import { useState } from 'react'
+
+export default function Signup() {
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [organization, setOrganization] = useState('')
+  const [error, setError] = useState('')
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError('')
+    const res = await fetch('/signup', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, password, organization }),
+    })
+    if (res.ok) {
+      alert('Account created!')
+    } else {
+      const data = await res.json()
+      setError(data.detail ?? 'Signup failed')
+    }
+  }
+
+  return (
+    <form onSubmit={submit} className="auth-form">
+      <h2>Create Account</h2>
+      {error && <div className="error">{error}</div>}
+      <input
+        type="email"
+        placeholder="Email"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        required
+      />
+      <input
+        type="password"
+        placeholder="Password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        required
+      />
+      <input
+        type="text"
+        placeholder="Organization"
+        value={organization}
+        onChange={(e) => setOrganization(e.target.value)}
+        required
+      />
+      <button type="submit">Sign Up</button>
+    </form>
+  )
+}


### PR DESCRIPTION
## Summary
- create FastAPI backend with signup/login and SQLAlchemy models
- add authentication pages in React using react-router
- split asset table out to `Home` component
- style login/signup forms
- document how to start backend

## Testing
- `python -m compileall backend`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install` *(fails: Invalid Version)*

------
https://chatgpt.com/codex/tasks/task_e_6842640bd5dc832bb8784487db81094c