### PR TITLE
Add asset CRUD

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,4 @@ uvicorn backend.main:app --reload
 ```
 
 The backend exposes `/signup` and `/login` endpoints for account creation and authentication.
+It also exposes CRUD endpoints under `/assets` to manage assets.

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,5 +1,6 @@
 from fastapi import FastAPI, Depends, HTTPException
 from sqlalchemy.orm import Session
+from typing import List
 from passlib.context import CryptContext
 
 from .database import SessionLocal, engine, Base
@@ -54,3 +55,47 @@ def login(credentials: schemas.UserLogin, db: Session = Depends(get_db)):
         raise HTTPException(status_code=400, detail="Invalid credentials")
     org = db_user.organization.name if db_user.organization else None
     return schemas.UserRead(id=db_user.id, email=db_user.email, organization=org)
+
+
+@app.post("/assets", response_model=schemas.AssetRead)
+def create_asset(asset: schemas.AssetCreate, db: Session = Depends(get_db)):
+    db_asset = models.Asset(name=asset.name, owner=asset.owner)
+    db.add(db_asset)
+    db.commit()
+    db.refresh(db_asset)
+    return db_asset
+
+
+@app.get("/assets", response_model=List[schemas.AssetRead])
+def list_assets(db: Session = Depends(get_db)):
+    return db.query(models.Asset).all()
+
+
+@app.get("/assets/{asset_id}", response_model=schemas.AssetRead)
+def get_asset(asset_id: int, db: Session = Depends(get_db)):
+    asset = db.query(models.Asset).filter(models.Asset.id == asset_id).first()
+    if not asset:
+        raise HTTPException(status_code=404, detail="Asset not found")
+    return asset
+
+
+@app.put("/assets/{asset_id}", response_model=schemas.AssetRead)
+def update_asset(asset_id: int, asset_update: schemas.AssetUpdate, db: Session = Depends(get_db)):
+    asset = db.query(models.Asset).filter(models.Asset.id == asset_id).first()
+    if not asset:
+        raise HTTPException(status_code=404, detail="Asset not found")
+    asset.name = asset_update.name
+    asset.owner = asset_update.owner
+    db.commit()
+    db.refresh(asset)
+    return asset
+
+
+@app.delete("/assets/{asset_id}")
+def delete_asset(asset_id: int, db: Session = Depends(get_db)):
+    asset = db.query(models.Asset).filter(models.Asset.id == asset_id).first()
+    if not asset:
+        raise HTTPException(status_code=404, detail="Asset not found")
+    db.delete(asset)
+    db.commit()
+    return {"detail": "deleted"}

--- a/backend/models.py
+++ b/backend/models.py
@@ -18,3 +18,11 @@ class User(Base):
     organization_id = Column(Integer, ForeignKey('organizations.id'))
 
     organization = relationship('Organization', back_populates='users')
+
+
+class Asset(Base):
+    __tablename__ = 'assets'
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, nullable=False)
+    owner = Column(String, nullable=False)
+

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -17,3 +17,23 @@ class UserRead(BaseModel):
 
     class Config:
         orm_mode = True
+
+
+class AssetBase(BaseModel):
+    name: str
+    owner: str
+
+
+class AssetCreate(AssetBase):
+    pass
+
+
+class AssetUpdate(AssetBase):
+    pass
+
+
+class AssetRead(AssetBase):
+    id: int
+
+    class Config:
+        orm_mode = True

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -59,6 +59,12 @@
   padding: 0.5rem;
 }
 
+.asset-form {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
 .error {
   color: red;
   margin-bottom: 0.5rem;

--- a/frontend/src/Home.tsx
+++ b/frontend/src/Home.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 
 interface Asset {
   id: number
@@ -7,11 +7,71 @@ interface Asset {
 }
 
 export default function Home() {
-  const [assets] = useState<Asset[]>([
-    { id: 1, name: 'Laptop - MacBook Pro', owner: 'Alice' },
-    { id: 2, name: 'Server - API 01', owner: 'Bob' },
-    { id: 3, name: 'Switch - Cisco 24p', owner: 'IT Dept' },
-  ])
+  const [assets, setAssets] = useState<Asset[]>([])
+  const [name, setName] = useState('')
+  const [owner, setOwner] = useState('')
+  const [editing, setEditing] = useState<Asset | null>(null)
+
+  const load = async () => {
+    const res = await fetch('/assets')
+    if (res.ok) {
+      setAssets(await res.json())
+    }
+  }
+
+  useEffect(() => {
+    load()
+  }, [])
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    const payload = { name, owner }
+    if (editing) {
+      const res = await fetch(`/assets/${editing.id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      })
+      if (res.ok) {
+        const updated = await res.json()
+        setAssets(assets.map((a) => (a.id === updated.id ? updated : a)))
+        setEditing(null)
+        setName('')
+        setOwner('')
+      }
+    } else {
+      const res = await fetch('/assets', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      })
+      if (res.ok) {
+        const created = await res.json()
+        setAssets([...assets, created])
+        setName('')
+        setOwner('')
+      }
+    }
+  }
+
+  const startEdit = (asset: Asset) => {
+    setEditing(asset)
+    setName(asset.name)
+    setOwner(asset.owner)
+  }
+
+  const cancelEdit = () => {
+    setEditing(null)
+    setName('')
+    setOwner('')
+  }
+
+  const remove = async (id: number) => {
+    const res = await fetch(`/assets/${id}`, { method: 'DELETE' })
+    if (res.ok) {
+      setAssets(assets.filter((a) => a.id !== id))
+    }
+  }
 
   return (
     <div className="container">
@@ -19,12 +79,35 @@ export default function Home() {
         <h1>Calioris Assets</h1>
       </header>
       <main>
+        <form onSubmit={submit} className="asset-form">
+          <input
+            type="text"
+            placeholder="Name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            required
+          />
+          <input
+            type="text"
+            placeholder="Owner"
+            value={owner}
+            onChange={(e) => setOwner(e.target.value)}
+            required
+          />
+          <button type="submit">{editing ? 'Update' : 'Add'}</button>
+          {editing && (
+            <button type="button" onClick={cancelEdit}>
+              Cancel
+            </button>
+          )}
+        </form>
         <table className="asset-table">
           <thead>
             <tr>
               <th>ID</th>
               <th>Name</th>
               <th>Owner</th>
+              <th></th>
             </tr>
           </thead>
           <tbody>
@@ -33,6 +116,14 @@ export default function Home() {
                 <td>{asset.id}</td>
                 <td>{asset.name}</td>
                 <td>{asset.owner}</td>
+                <td>
+                  <button type="button" onClick={() => startEdit(asset)}>
+                    Edit
+                  </button>
+                  <button type="button" onClick={() => remove(asset.id)}>
+                    Delete
+                  </button>
+                </td>
               </tr>
             ))}
           </tbody>


### PR DESCRIPTION
## Summary
- add Asset model and CRUD routes to backend
- add Asset schemas
- connect React frontend Home view to new API
- allow creating, editing and deleting assets
- style asset form
- document new endpoints in README

## Testing
- `python -m py_compile backend/*.py`
- `npx tsc -p tsconfig.app.json --noEmit` *(fails: Cannot find module 'react' etc. because npm install fails with "Invalid Version" error)*


------
https://chatgpt.com/codex/tasks/task_e_68427e51347c832b992ad1ad189ea18f