### PR TITLE
Refactor React pages into reusable components

### DIFF
--- a/frontend/src/Home.tsx
+++ b/frontend/src/Home.tsx
@@ -1,4 +1,6 @@
 import { useEffect, useState } from 'react'
+import AssetForm from './components/AssetForm'
+import AssetRow from './components/AssetRow'
 
 interface Asset {
   id: number
@@ -79,28 +81,15 @@ export default function Home() {
         <h1>Calioris Assets</h1>
       </header>
       <main>
-        <form onSubmit={submit} className="asset-form">
-          <input
-            type="text"
-            placeholder="Name"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            required
-          />
-          <input
-            type="text"
-            placeholder="Owner"
-            value={owner}
-            onChange={(e) => setOwner(e.target.value)}
-            required
-          />
-          <button type="submit">{editing ? 'Update' : 'Add'}</button>
-          {editing && (
-            <button type="button" onClick={cancelEdit}>
-              Cancel
-            </button>
-          )}
-        </form>
+        <AssetForm
+          name={name}
+          owner={owner}
+          editing={!!editing}
+          onNameChange={setName}
+          onOwnerChange={setOwner}
+          onSubmit={submit}
+          onCancel={cancelEdit}
+        />
         <table className="asset-table">
           <thead>
             <tr>
@@ -112,19 +101,12 @@ export default function Home() {
           </thead>
           <tbody>
             {assets.map((asset) => (
-              <tr key={asset.id}>
-                <td>{asset.id}</td>
-                <td>{asset.name}</td>
-                <td>{asset.owner}</td>
-                <td>
-                  <button type="button" onClick={() => startEdit(asset)}>
-                    Edit
-                  </button>
-                  <button type="button" onClick={() => remove(asset.id)}>
-                    Delete
-                  </button>
-                </td>
-              </tr>
+              <AssetRow
+                key={asset.id}
+                asset={asset}
+                onEdit={startEdit}
+                onDelete={remove}
+              />
             ))}
           </tbody>
         </table>

--- a/frontend/src/Login.tsx
+++ b/frontend/src/Login.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import AuthForm from './components/AuthForm'
 
 export default function Login() {
   const [email, setEmail] = useState('')
@@ -22,9 +23,12 @@ export default function Login() {
   }
 
   return (
-    <form onSubmit={submit} className="auth-form">
-      <h2>Login</h2>
-      {error && <div className="error">{error}</div>}
+    <AuthForm
+      title="Login"
+      onSubmit={submit}
+      error={error}
+      submitLabel="Login"
+    >
       <input
         type="email"
         placeholder="Email"
@@ -39,7 +43,6 @@ export default function Login() {
         onChange={(e) => setPassword(e.target.value)}
         required
       />
-      <button type="submit">Login</button>
-    </form>
+    </AuthForm>
   )
 }

--- a/frontend/src/Signup.tsx
+++ b/frontend/src/Signup.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import AuthForm from './components/AuthForm'
 
 export default function Signup() {
   const [email, setEmail] = useState('')
@@ -23,9 +24,12 @@ export default function Signup() {
   }
 
   return (
-    <form onSubmit={submit} className="auth-form">
-      <h2>Create Account</h2>
-      {error && <div className="error">{error}</div>}
+    <AuthForm
+      title="Create Account"
+      onSubmit={submit}
+      error={error}
+      submitLabel="Sign Up"
+    >
       <input
         type="email"
         placeholder="Email"
@@ -47,7 +51,6 @@ export default function Signup() {
         onChange={(e) => setOrganization(e.target.value)}
         required
       />
-      <button type="submit">Sign Up</button>
-    </form>
+    </AuthForm>
   )
 }

--- a/frontend/src/components/AssetForm.tsx
+++ b/frontend/src/components/AssetForm.tsx
@@ -1,0 +1,46 @@
+import type { FormEvent } from 'react'
+
+interface AssetFormProps {
+  name: string
+  owner: string
+  editing?: boolean
+  onNameChange: (value: string) => void
+  onOwnerChange: (value: string) => void
+  onSubmit: (e: FormEvent) => void
+  onCancel?: () => void
+}
+
+export default function AssetForm({
+  name,
+  owner,
+  editing = false,
+  onNameChange,
+  onOwnerChange,
+  onSubmit,
+  onCancel,
+}: AssetFormProps) {
+  return (
+    <form onSubmit={onSubmit} className="asset-form">
+      <input
+        type="text"
+        placeholder="Name"
+        value={name}
+        onChange={(e) => onNameChange(e.target.value)}
+        required
+      />
+      <input
+        type="text"
+        placeholder="Owner"
+        value={owner}
+        onChange={(e) => onOwnerChange(e.target.value)}
+        required
+      />
+      <button type="submit">{editing ? 'Update' : 'Add'}</button>
+      {editing && onCancel && (
+        <button type="button" onClick={onCancel}>
+          Cancel
+        </button>
+      )}
+    </form>
+  )
+}

--- a/frontend/src/components/AssetRow.tsx
+++ b/frontend/src/components/AssetRow.tsx
@@ -1,0 +1,29 @@
+interface Asset {
+  id: number
+  name: string
+  owner: string
+}
+
+interface AssetRowProps {
+  asset: Asset
+  onEdit: (asset: Asset) => void
+  onDelete: (id: number) => void
+}
+
+export default function AssetRow({ asset, onEdit, onDelete }: AssetRowProps) {
+  return (
+    <tr>
+      <td>{asset.id}</td>
+      <td>{asset.name}</td>
+      <td>{asset.owner}</td>
+      <td>
+        <button type="button" onClick={() => onEdit(asset)}>
+          Edit
+        </button>
+        <button type="button" onClick={() => onDelete(asset.id)}>
+          Delete
+        </button>
+      </td>
+    </tr>
+  )
+}

--- a/frontend/src/components/AuthForm.tsx
+++ b/frontend/src/components/AuthForm.tsx
@@ -1,0 +1,26 @@
+import type { FormEvent, ReactNode } from 'react'
+
+interface AuthFormProps {
+  title: string
+  error?: string
+  submitLabel: string
+  onSubmit: (e: FormEvent) => void
+  children: ReactNode
+}
+
+export default function AuthForm({
+  title,
+  error,
+  submitLabel,
+  onSubmit,
+  children,
+}: AuthFormProps) {
+  return (
+    <form onSubmit={onSubmit} className="auth-form">
+      <h2>{title}</h2>
+      {error && <div className="error">{error}</div>}
+      {children}
+      <button type="submit">{submitLabel}</button>
+    </form>
+  )
+}

--- a/frontend/src/components/AuthForm.tsx
+++ b/frontend/src/components/AuthForm.tsx
@@ -18,7 +18,7 @@ export default function AuthForm({
   return (
     <form onSubmit={onSubmit} className="auth-form">
       <h2>{title}</h2>
-      {error && <div className="error">{error}</div>}
+      {error && <div className="error" aria-live="assertive">{error}</div>}
       {children}
       <button type="submit">{submitLabel}</button>
     </form>


### PR DESCRIPTION
## Summary
- extract AuthForm, AssetForm and AssetRow components
- use these components in Home, Login and Signup

## Testing
- `yarn build`
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68427fc155f0832b976081a3f8fe478e