### PR TITLE
Add basic stock management module

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,4 @@ uvicorn backend.main:app --reload
 
 The backend exposes `/signup` and `/login` endpoints for account creation and authentication.
 It also exposes CRUD endpoints under `/assets` to manage assets.
+Additionally, a stock management module is available via `/stock_items` for tracking inventory.

--- a/backend/README.md
+++ b/backend/README.md
@@ -12,3 +12,9 @@ uvicorn backend.main:app --reload
 ```
 
 The default database is a local SQLite file `app.db`. You can override the database URL using the `DATABASE_URL` environment variable (e.g. a PostgreSQL connection string).
+
+### Endpoints
+
+- `/signup` and `/login` for user accounts.
+- `/assets` for managing IT assets.
+- `/stock_items` for managing inventory stock levels.

--- a/backend/main.py
+++ b/backend/main.py
@@ -99,3 +99,52 @@ def delete_asset(asset_id: int, db: Session = Depends(get_db)):
     db.delete(asset)
     db.commit()
     return {"detail": "deleted"}
+
+
+@app.post("/stock_items", response_model=schemas.StockItemRead)
+def create_stock_item(item: schemas.StockItemCreate, db: Session = Depends(get_db)):
+    db_item = models.StockItem(
+        name=item.name, quantity=item.quantity, location=item.location
+    )
+    db.add(db_item)
+    db.commit()
+    db.refresh(db_item)
+    return db_item
+
+
+@app.get("/stock_items", response_model=List[schemas.StockItemRead])
+def list_stock_items(db: Session = Depends(get_db)):
+    return db.query(models.StockItem).all()
+
+
+@app.get("/stock_items/{item_id}", response_model=schemas.StockItemRead)
+def get_stock_item(item_id: int, db: Session = Depends(get_db)):
+    item = db.query(models.StockItem).filter(models.StockItem.id == item_id).first()
+    if not item:
+        raise HTTPException(status_code=404, detail="Item not found")
+    return item
+
+
+@app.put("/stock_items/{item_id}", response_model=schemas.StockItemRead)
+def update_stock_item(
+    item_id: int, item_update: schemas.StockItemUpdate, db: Session = Depends(get_db)
+):
+    item = db.query(models.StockItem).filter(models.StockItem.id == item_id).first()
+    if not item:
+        raise HTTPException(status_code=404, detail="Item not found")
+    item.name = item_update.name
+    item.quantity = item_update.quantity
+    item.location = item_update.location
+    db.commit()
+    db.refresh(item)
+    return item
+
+
+@app.delete("/stock_items/{item_id}")
+def delete_stock_item(item_id: int, db: Session = Depends(get_db)):
+    item = db.query(models.StockItem).filter(models.StockItem.id == item_id).first()
+    if not item:
+        raise HTTPException(status_code=404, detail="Item not found")
+    db.delete(item)
+    db.commit()
+    return {"detail": "deleted"}

--- a/backend/models.py
+++ b/backend/models.py
@@ -26,3 +26,11 @@ class Asset(Base):
     name = Column(String, nullable=False)
     owner = Column(String, nullable=False)
 
+
+class StockItem(Base):
+    __tablename__ = 'stock_items'
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, nullable=False)
+    quantity = Column(Integer, nullable=False)
+    location = Column(String, nullable=True)
+

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -37,3 +37,24 @@ class AssetRead(AssetBase):
 
     class Config:
         orm_mode = True
+
+
+class StockItemBase(BaseModel):
+    name: str
+    quantity: int
+    location: Optional[str] = None
+
+
+class StockItemCreate(StockItemBase):
+    pass
+
+
+class StockItemUpdate(StockItemBase):
+    pass
+
+
+class StockItemRead(StockItemBase):
+    id: int
+
+    class Config:
+        orm_mode = True

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import { BrowserRouter, Routes, Route, Link } from 'react-router-dom'
 import Home from './Home'
 import Login from './Login'
 import Signup from './Signup'
+import Stock from './Stock'
 import './App.css'
 
 export default function App() {
@@ -11,11 +12,13 @@ export default function App() {
         <Link to="/">Home</Link>
         <Link to="/login">Login</Link>
         <Link to="/signup">Sign Up</Link>
+        <Link to="/stock">Stock</Link>
       </nav>
       <Routes>
         <Route path="/" element={<Home />} />
         <Route path="/login" element={<Login />} />
         <Route path="/signup" element={<Signup />} />
+        <Route path="/stock" element={<Stock />} />
       </Routes>
     </BrowserRouter>
   )

--- a/frontend/src/Stock.tsx
+++ b/frontend/src/Stock.tsx
@@ -40,9 +40,7 @@ export default function Stock() {
         const updated = await res.json()
         setItems(items.map((i) => (i.id === updated.id ? updated : i)))
         setEditing(null)
-        setName('')
-        setQuantity(0)
-        setLocation('')
+        resetForm()
       }
     } else {
       const res = await fetch('/stock_items', {

--- a/frontend/src/Stock.tsx
+++ b/frontend/src/Stock.tsx
@@ -1,0 +1,125 @@
+import { useEffect, useState } from 'react'
+import StockForm from './components/StockForm'
+import StockRow from './components/StockRow'
+
+interface StockItem {
+  id: number
+  name: string
+  quantity: number
+  location?: string
+}
+
+export default function Stock() {
+  const [items, setItems] = useState<StockItem[]>([])
+  const [name, setName] = useState('')
+  const [quantity, setQuantity] = useState(0)
+  const [location, setLocation] = useState('')
+  const [editing, setEditing] = useState<StockItem | null>(null)
+
+  const load = async () => {
+    const res = await fetch('/stock_items')
+    if (res.ok) {
+      setItems(await res.json())
+    }
+  }
+
+  useEffect(() => {
+    load()
+  }, [])
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    const payload = { name, quantity, location }
+    if (editing) {
+      const res = await fetch(`/stock_items/${editing.id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      })
+      if (res.ok) {
+        const updated = await res.json()
+        setItems(items.map((i) => (i.id === updated.id ? updated : i)))
+        setEditing(null)
+        setName('')
+        setQuantity(0)
+        setLocation('')
+      }
+    } else {
+      const res = await fetch('/stock_items', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      })
+      if (res.ok) {
+        const created = await res.json()
+        setItems([...items, created])
+        setName('')
+        setQuantity(0)
+        setLocation('')
+      }
+    }
+  }
+
+  const startEdit = (item: StockItem) => {
+    setEditing(item)
+    setName(item.name)
+    setQuantity(item.quantity)
+    setLocation(item.location ?? '')
+  }
+
+  const cancelEdit = () => {
+    setEditing(null)
+    setName('')
+    setQuantity(0)
+    setLocation('')
+  }
+
+  const remove = async (id: number) => {
+    const res = await fetch(`/stock_items/${id}`, { method: 'DELETE' })
+    if (res.ok) {
+      setItems(items.filter((i) => i.id !== id))
+    }
+  }
+
+  return (
+    <div className="container">
+      <header className="header">
+        <h1>Stock Items</h1>
+      </header>
+      <main>
+        <StockForm
+          name={name}
+          quantity={quantity}
+          location={location}
+          editing={!!editing}
+          onNameChange={setName}
+          onQuantityChange={setQuantity}
+          onLocationChange={setLocation}
+          onSubmit={submit}
+          onCancel={cancelEdit}
+        />
+        <table className="asset-table">
+          <thead>
+            <tr>
+              <th>ID</th>
+              <th>Name</th>
+              <th>Quantity</th>
+              <th>Location</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            {items.map((item) => (
+              <StockRow
+                key={item.id}
+                item={item}
+                onEdit={startEdit}
+                onDelete={remove}
+              />
+            ))}
+          </tbody>
+        </table>
+      </main>
+    </div>
+  )
+}

--- a/frontend/src/components/StockForm.tsx
+++ b/frontend/src/components/StockForm.tsx
@@ -1,0 +1,56 @@
+import type { FormEvent } from 'react'
+
+interface StockFormProps {
+  name: string
+  quantity: number
+  location: string
+  editing?: boolean
+  onNameChange: (value: string) => void
+  onQuantityChange: (value: number) => void
+  onLocationChange: (value: string) => void
+  onSubmit: (e: FormEvent) => void
+  onCancel?: () => void
+}
+
+export default function StockForm({
+  name,
+  quantity,
+  location,
+  editing = false,
+  onNameChange,
+  onQuantityChange,
+  onLocationChange,
+  onSubmit,
+  onCancel,
+}: StockFormProps) {
+  return (
+    <form onSubmit={onSubmit} className="stock-form">
+      <input
+        type="text"
+        placeholder="Name"
+        value={name}
+        onChange={(e) => onNameChange(e.target.value)}
+        required
+      />
+      <input
+        type="number"
+        placeholder="Quantity"
+        value={quantity}
+        onChange={(e) => onQuantityChange(Number(e.target.value))}
+        required
+      />
+      <input
+        type="text"
+        placeholder="Location"
+        value={location}
+        onChange={(e) => onLocationChange(e.target.value)}
+      />
+      <button type="submit">{editing ? 'Update' : 'Add'}</button>
+      {editing && onCancel && (
+        <button type="button" onClick={onCancel}>
+          Cancel
+        </button>
+      )}
+    </form>
+  )
+}

--- a/frontend/src/components/StockRow.tsx
+++ b/frontend/src/components/StockRow.tsx
@@ -1,0 +1,31 @@
+interface StockItem {
+  id: number
+  name: string
+  quantity: number
+  location?: string
+}
+
+interface StockRowProps {
+  item: StockItem
+  onEdit: (item: StockItem) => void
+  onDelete: (id: number) => void
+}
+
+export default function StockRow({ item, onEdit, onDelete }: StockRowProps) {
+  return (
+    <tr>
+      <td>{item.id}</td>
+      <td>{item.name}</td>
+      <td>{item.quantity}</td>
+      <td>{item.location ?? '-'}</td>
+      <td>
+        <button type="button" onClick={() => onEdit(item)}>
+          Edit
+        </button>
+        <button type="button" onClick={() => onDelete(item.id)}>
+          Delete
+        </button>
+      </td>
+    </tr>
+  )
+}


### PR DESCRIPTION
## Summary
- add new StockItem ORM model and Pydantic schemas
- expose CRUD API endpoints under `/stock_items`
- document new stock endpoints in README files
- create frontend stock management page and components
- add navigation link to Stock page

## Testing
- `pytest -q`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install` *(fails: Invalid Version)*

------
https://chatgpt.com/codex/tasks/task_e_6842830a8c04832bb22a410299c1d37c